### PR TITLE
Feature data unification

### DIFF
--- a/tdei-api-gateway.json
+++ b/tdei-api-gateway.json
@@ -125,10 +125,10 @@
                             }
                         },
                         "example": [
-                            23.5,
-                            34.65,
-                            89.5,
-                            65.98
+                            -122.153539,
+                            47.635463,
+                            -122.116939,
+                            47.65387
                         ]
                     },
                     {
@@ -228,7 +228,7 @@
                         }
                     },
                     {
-                        "name": "osw_schema_version",
+                        "name": "schema_version",
                         "in": "query",
                         "description": "version name of the osw schema version that the application requests. list of versions can be found with /api/v1/osw/versions.",
                         "required": false,
@@ -264,9 +264,9 @@
                         }
                     },
                     {
-                        "name": "tdei_record_id",
+                        "name": "tdei_dataset_id",
                         "in": "query",
-                        "description": "tdei_record_id, unique id represents file.",
+                        "description": "tdei_dataset_id, unique id represents file.",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -297,13 +297,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful response - returns an array of [OswDownload](#/components/schemas/OswDownload) entities.",
+                        "description": "Successful response - returns an array of [OswDatasetItem](#/components/schemas/OswDatasetItem) entities.",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/OswDownload"
+                                        "$ref": "#/components/schemas/OswDatasetItem"
                                     }
                                 }
                             }
@@ -332,7 +332,7 @@
                     "OSW"
                 ],
                 "summary": "upload a pre-release of OSW dataset.",
-                "description": "This path allows a user to upload pre-release osw dataset. The caller must provide metadata about the file - includes information about how and when the data was collected and valid dates of the file. Returns the tdei_record_id of the uploaded file.",
+                "description": "This path allows a user to upload pre-release osw dataset. The caller must provide metadata about the file - includes information about how and when the data was collected and valid dates of the file. Returns the job_id of the uploaded file. For checking the status of the upload, refer to the Location header in the response, which contains the URL for the status API endpoint.",
                 "operationId": "uploadOswFile",
                 "parameters": [
                     {
@@ -396,7 +396,7 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "The request has been accepted for processing. returns the tdei_record_id, unique identifier for uploaded file.",
+                        "description": "The request has been accepted for processing. returns the job_id, unique identifier for uploaded file.",
                         "content": {
                             "application/text": {
                                 "schema": {
@@ -433,19 +433,19 @@
                 ]
             }
         },
-        "/api/v1/osw/publish/{tdei_record_id}": {
+        "/api/v1/osw/publish/{tdei_dataset_id}": {
             "post": {
                 "tags": [
                     "OSW"
                 ],
-                "summary": "Publishes the OSW dataset for the tdei_record_id",
-                "description": "Publishes an OSW dataset that was previously uploaded via the [POST] /osw endpoint, marking it as an official release for the mobility service. This official release status ensures visibility to all TDEI data consumers.",
+                "summary": "Publishes the OSW dataset for the tdei_dataset_id",
+                "description": "Publishes an OSW dataset that was previously uploaded via the [POST] /osw endpoint, marking it as an official release for the mobility service. This official release status ensures visibility to all TDEI data consumers. Returns the job_id of the uploaded file. For checking the status of the upload, refer to the Location header in the response, which contains the URL for the status API endpoint.",
                 "operationId": "publishOswFile",
                 "parameters": [
                     {
-                        "name": "tdei_record_id",
+                        "name": "tdei_dataset_id",
                         "in": "path",
-                        "description": "tdei_record_id for a file, represented as a uuid",
+                        "description": "tdei_dataset_id for a file, represented as a uuid",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -454,7 +454,7 @@
                 ],
                 "responses": {
                     "202": {
-                        "description": "The request has been accepted for processing. returns the tdei_record_id, unique identifier for publish request.",
+                        "description": "The request has been accepted for processing. returns the job_id, unique identifier for publish request.",
                         "content": {
                             "application/text": {
                                 "schema": {
@@ -481,7 +481,7 @@
                         "description": "This request is unauthorized."
                     },
                     "404": {
-                        "description": "A file with the specified tdei_record_id was not found. Use the [GET] /api/v1/osw endpoint to find valid file ids.",
+                        "description": "A file with the specified tdei_dataset_id was not found. Use the [GET] /api/v1/osw endpoint to find valid file ids.",
                         "content": {
                             "text/plain": {}
                         }
@@ -506,7 +506,7 @@
                     "OSW"
                 ],
                 "summary": "Validates the osw dataset.",
-                "description": "Allows a user to validate osw dataset to check the correctness of data. Returns the job_id associated with validation job.",
+                "description": "Allows a user to validate osw dataset to check the correctness of data. Returns the job_id for validation request. For checking the status, refer to the Location header in the response, which contains the URL for the status API endpoint.",
                 "operationId": "validateOswFile",
                 "requestBody": {
                     "content": {
@@ -572,7 +572,7 @@
                     "OSW"
                 ],
                 "summary": "OSW reformatting on demand",
-                "description": "upload a file and request for file format conversion",
+                "description": "upload a file and request for file format conversion. Returns the job_id for convert request. For checking the status, refer to the Location header in the response, which contains the URL for the status API endpoint.",
                 "operationId": "oswOnDemandFormat",
                 "requestBody": {
                     "content": {
@@ -615,12 +615,20 @@
                 },
                 "responses": {
                     "202": {
-                        "description": " Created formatting job_id ",
+                        "description": "The request has been accepted for processing. returns the job_id, unique identifier for convert job request.",
                         "content": {
-                            "application/json": {
+                            "application/text": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/OSWFormatResponse"
+                                    "type": "string"
                                 }
+                            }
+                        },
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Location api to find the status of request processing"
                             }
                         }
                     },
@@ -636,32 +644,41 @@
                 }
             }
         },
-        "/api/v1/osw/confidence/calculate": {
+        "/api/v1/osw/confidence/calculate/{tdei_dataset_id}": {
             "post": {
                 "tags": [
                     "OSW"
                 ],
                 "summary": "Initiate Confidence calculation for a dataset",
-                "description": "Initiates the confidence calculation of a tdei_record_id as mentioned in the body",
+                "description": "Initiates the confidence calculation for requested tdei_dataset_id. Returns the job_id for confidence calculation request. For checking the status, refer to the Location header in the response, which contains the URL for the status API endpoint.",
                 "operationId": "oswConfidenceCalculate",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OSWConfidenceRequest"
-                            }
+                "parameters": [
+                    {
+                        "name": "tdei_dataset_id",
+                        "in": "path",
+                        "description": "tdei_dataset_id for a file, represented as a uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
-                    },
-                    "required": true
-                },
+                    }
+                ],
                 "responses": {
                     "202": {
-                        "description": " Created confidence job_id ",
+                        "description": "The request has been accepted for processing. returns the job_id, unique identifier for convert job request.",
                         "content": {
-                            "application/json": {
+                            "application/text": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/OSWConfidenceResponse"
+                                    "type": "string"
                                 }
+                            }
+                        },
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Location api to find the status of request processing"
                             }
                         }
                     },
@@ -669,7 +686,7 @@
                         "description": "This request is unauthenticated."
                     },
                     "404": {
-                        "description": "tdei_record_id is not found"
+                        "description": "tdei_dataset_id is not found"
                     },
                     "500": {
                         "description": "An server error occurred."
@@ -713,140 +730,7 @@
                 ]
             }
         },
-        "/api/v1/osw/confidence/status/{job_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Get the status of confidence request",
-                "description": "Fetches the status of confidence request job.",
-                "operationId": "getOSWConfidenceStatus",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "path",
-                        "description": "job_id for confidence request",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the status of Confidence request.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OSWConfidenceStatus"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "404": {
-                        "description": "job_id not found"
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "AuthorizationToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/osw/convert/status/{job_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Fetch status of format request",
-                "description": "Summary of the formatting request",
-                "operationId": "oswFormatStatus",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "path",
-                        "description": "job_id for format request",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": " Status of the formatting Job ",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OSWFormatStatusResponse"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "404": {
-                        "description": "job_id not found"
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                }
-            }
-        },
-        "/api/v1/osw/convert/download/{job_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Downloads the converted file",
-                "description": "Downloads the converted file from the job",
-                "operationId": "oswFormatDownload",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "path",
-                        "description": "job_id for format request",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Downloadable stream of the file",
-                        "content": {
-                            "application/octet-stream": {}
-                        }
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "404": {
-                        "description": "job_id not found"
-                    },
-                    "400": {
-                        "description": "job_id is not complete"
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                }
-            }
-        },
-        "/api/v1/osw/{tdei_record_id}": {
+        "/api/v1/osw/{tdei_dataset_id}": {
             "get": {
                 "tags": [
                     "OSW"
@@ -856,9 +740,9 @@
                 "operationId": "getOswFile",
                 "parameters": [
                     {
-                        "name": "tdei_record_id",
+                        "name": "tdei_dataset_id",
                         "in": "path",
-                        "description": "tdei_record_id for a file, represented as a uuid",
+                        "description": "tdei_dataset_id for a file, represented as a uuid",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -889,58 +773,7 @@
                         "description": "This request is unauthenticated."
                     },
                     "404": {
-                        "description": "A file with the specified tdei_record_id was not found. Use the /api/v1/osw endpoints to find valid file ids.",
-                        "content": {
-                            "application/json": {}
-                        }
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "AuthorizationToken": []
-                    }
-                ]
-            },
-            "delete": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Invalidates the OSW record",
-                "description": "Returns boolean true if the action is successful",
-                "operationId": "deleteOsw",
-                "parameters": [
-                    {
-                        "name": "tdei_record_id",
-                        "in": "path",
-                        "description": "tdei_record_id for a file, represented as a uuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns true if action is successful.",
-                        "content": {
-                            "application/text": {
-                                "schema": {
-                                    "type": "boolean"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "400": {
-                        "description": "The specified tdei_record_id was not found. Use the [GET] /api/v1/osw endpoints to find valid tdei_record_id.",
+                        "description": "A file with the specified tdei_dataset_id was not found. Use the /api/v1/osw endpoints to find valid file ids.",
                         "content": {
                             "application/json": {}
                         }
@@ -1673,140 +1506,6 @@
                 ]
             }
         },
-        "/api/v1/osw/upload/status/{tdei_record_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Get the upload status",
-                "description": "Fetches the status of an uploaded record",
-                "operationId": "getUploadStatus",
-                "parameters": [
-                    {
-                        "name": "tdei_record_id",
-                        "in": "path",
-                        "description": "tdei_record_id received during upload",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns status of record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/RecordUploadStatus"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Record not found"
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                }
-            }
-        },
-        "/api/v1/osw/publish/status/{tdei_record_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Get the publish status",
-                "description": "Fetches the status of an published record",
-                "operationId": "getPublishStatus",
-                "parameters": [
-                    {
-                        "name": "tdei_record_id",
-                        "in": "path",
-                        "description": "tdei_record_id received during upload",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns status of record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/RecordPublishStatus"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Record not found"
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                }
-            }
-        },
-        "/api/v1/osw/validate/status/{job_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Get the status of the validation request.",
-                "description": "Fetches the status of the validation request job.",
-                "operationId": "getValidateStatus",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "path",
-                        "description": "job_id for the validation request",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the status of the validation request.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationStatus"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "404": {
-                        "description": "job_id not found"
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "AuthorizationToken": []
-                    }
-                ]
-            }
-        },
         "/api/v1/project-group": {
             "get": {
                 "tags": [
@@ -1948,13 +1647,13 @@
                 }
             }
         },
-        "/api/v1/osw/dataset-flattern/{tdei_record_id}": {
+        "/api/v1/osw/dataset-flattern/{tdei_dataset_id}": {
             "post": {
                 "tags": [
                     "OSW"
                 ],
                 "summary": "Flatterns an OSW dataset",
-                "description": "Flatterns an OSW dataset for provided tdei_record_id.",
+                "description": "Flatterns an OSW dataset for provided tdei_dataset_id.",
                 "operationId": "datasetFlatternById",
                 "parameters": [
                     {
@@ -1967,9 +1666,9 @@
                         }
                     },
                     {
-                        "name": "tdei_record_id",
+                        "name": "tdei_dataset_id",
                         "in": "path",
-                        "description": "tdei_record_id for a file, represented as a uuid",
+                        "description": "tdei_dataset_id for a file, represented as a uuid",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2005,60 +1704,10 @@
                         "description": "This request is unauthorized."
                     },
                     "404": {
-                        "description": "A file with the specified tdei_record_id was not found. Use the [GET] /api/v1/osw endpoint to find valid file ids.",
+                        "description": "A file with the specified tdei_dataset_id was not found. Use the [GET] /api/v1/osw endpoint to find valid file ids.",
                         "content": {
                             "text/plain": {}
                         }
-                    },
-                    "500": {
-                        "description": "An server error occurred."
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "AuthorizationToken": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/osw/dataset-flattern/status/{job_id}": {
-            "get": {
-                "tags": [
-                    "OSW"
-                ],
-                "summary": "Get the status of the flattening request.",
-                "description": "Fetches the status of the flattening request job.",
-                "operationId": "getdataset-flattern-status",
-                "parameters": [
-                    {
-                        "name": "job_id",
-                        "in": "path",
-                        "description": "job_id for the flattening request",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the status of the flattening request.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FlatteningStatus"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "This request is unauthenticated."
-                    },
-                    "404": {
-                        "description": "job_id not found"
                     },
                     "500": {
                         "description": "An server error occurred."
@@ -2079,14 +1728,14 @@
                 "tags": [
                     "OSW"
                 ],
-                "summary": "Given a dataset tdei_record_id returns the subgraph within a given bounding box.",
-                "description": "Given a dataset tdei_record_id returns the subgraph within a given bounding box (xmin, ymin, ymax, xmax).",
+                "summary": "Given a dataset tdei_dataset_id returns the subgraph within a given bounding box.",
+                "description": "Given a dataset tdei_dataset_id returns the subgraph within a given bounding box (xmin, ymin, ymax, xmax). Returns the job_id for convert request. For checking the status, refer to the Location header in the response, which contains the URL for the status API endpoint.",
                 "operationId": "datasetBbox",
                 "parameters": [
                     {
-                        "name": "tdei_record_id",
+                        "name": "tdei_dataset_id",
                         "in": "query",
-                        "description": "tdei_record_id for a file, represented as a uuid",
+                        "description": "tdei_dataset_id for a file, represented as a uuid",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2107,10 +1756,10 @@
                             }
                         },
                         "example": [
-                            23.5,
-                            34.65,
-                            89.5,
-                            65.98
+                            -122.153539,
+                            47.635463,
+                            -122.116939,
+                            47.65387
                         ]
                     }
                 ],
@@ -2148,37 +1797,106 @@
                 },
                 "security": [
                     {
+                        "ApiKey": []
+                    },
+                    {
                         "AuthorizationToken": []
                     }
                 ]
             }
         },
-        "/api/v1/osw/dataset-bbox/status/{job_id}": {
+        "/api/v1/job": {
             "get": {
                 "tags": [
-                    "OSW"
+                    "General"
                 ],
-                "summary": "Fetch status of dataset bounding box request",
-                "description": "Summary of the dataset bounding box request",
-                "operationId": "datset-bbox-status",
+                "summary": "List job details.",
+                "description": "This endpoint returns a list of jobs with status and request details.",
+                "operationId": "listJobs",
                 "parameters": [
                     {
                         "name": "job_id",
-                        "in": "path",
-                        "description": "job_id for dataset bounding box request",
-                        "required": true,
+                        "in": "query",
+                        "description": "job_id uniquely identifies the job request.",
+                        "required": false,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "name": "job_type",
+                        "in": "query",
+                        "description": "job_type of the job.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "Confidence-Calculate",
+                                "Dataset-Reformat",
+                                "Dataset-Upload",
+                                "Dataset-Publish",
+                                "Dataset-Validate",
+                                "Dataset-Flatten",
+                                "Dataset-Queries"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Status of the job.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "COMPLETED",
+                                "FAILED",
+                                "IN-PROGRESS"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tdei_project_group_id",
+                        "in": "query",
+                        "description": "project group id. Represented as a UUID.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page_no",
+                        "in": "query",
+                        "description": "Integer, defaults to 1.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 1
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "in": "query",
+                        "description": "page size. integer, between 1 to 50, defaults to 10.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Status of the dataset bounding box Job",
+                        "description": "Successful response - returns an array of [JobDetails](#/components/schemas/JobDetails) entities.",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/DatasetBboxStatus"
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/JobDetails"
+                                    }
                                 }
                             }
                         }
@@ -2186,28 +1904,33 @@
                     "401": {
                         "description": "This request is unauthenticated."
                     },
-                    "404": {
-                        "description": "job_id not found"
-                    },
                     "500": {
                         "description": "An server error occurred."
                     }
-                }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "AuthorizationToken": []
+                    }
+                ]
             }
         },
-        "/api/v1/osw/dataset-bbox/download/{job_id}": {
+        "/api/v1/job/download/{job_id}": {
             "get": {
                 "tags": [
-                    "OSW"
+                    "General"
                 ],
-                "summary": "Downloads the dataset file",
+                "summary": "Downloads the job download file",
                 "description": "Downloads the dataset generated by the job",
-                "operationId": "dataset-bbox-download",
+                "operationId": "job-download",
                 "parameters": [
                     {
                         "name": "job_id",
                         "in": "path",
-                        "description": "job_id for dataset bounding box request",
+                        "description": "job_id uniquely represents the job request",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2225,15 +1948,73 @@
                         "description": "This request is unauthenticated."
                     },
                     "404": {
-                        "description": "job_id not found"
+                        "description": "download file not found"
                     },
                     "400": {
-                        "description": "job_id is not complete"
+                        "description": "job_id not found"
                     },
                     "500": {
                         "description": "An server error occurred."
                     }
-                }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "AuthorizationToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/dataset/{tdei_dataset_id}": {
+            "delete": {
+                "tags": [
+                    "General"
+                ],
+                "summary": "Invalidates the Dataset",
+                "description": "Returns boolean true if the action is successful.",
+                "operationId": "deleteDataset",
+                "parameters": [
+                    {
+                        "name": "tdei_dataset_id",
+                        "in": "path",
+                        "description": "tdei_dataset_id for a file, represented as a uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns true if action is successful.",
+                        "content": {
+                            "application/text": {
+                                "schema": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "This request is unauthenticated."
+                    },
+                    "400": {
+                        "description": "The specified tdei_dataset_id was not found or record already invalidated.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "500": {
+                        "description": "An server error occurred."
+                    }
+                },
+                "security": [
+                    {
+                        "AuthorizationToken": []
+                    }
+                ]
             }
         }
     },
@@ -2818,7 +2599,7 @@
                 },
                 "description": "Describes the status of an publish record"
             },
-            "OswDownload": {
+            "OswDatasetItem": {
                 "required": [
                     "name",
                     "version",
@@ -2924,12 +2705,12 @@
                     "dataset_area": {
                         "$ref": "#/components/schemas/GeoJsonObject"
                     },
-                    "tdei_record_id": {
+                    "tdei_dataset_id": {
                         "type": "string",
                         "description": "unique id identifying the file in the tdei system, can be used to retrieve the file itself.",
                         "example": "4e991e7a-5c16-4ebf-ad31-3a3625bcca10"
                     },
-                    "osw_schema_version": {
+                    "schema_version": {
                         "type": "string",
                         "description": "version of osw schema this file conforms to",
                         "example": "v1.1"
@@ -2937,7 +2718,7 @@
                     "download_url": {
                         "type": "string",
                         "description": "The url from which this file can be downloaded.",
-                        "example": "/api/v1/osw/{tdei_record_id}"
+                        "example": "/api/v1/osw/{tdei_dataset_id}"
                     }
                 },
                 "description": "represents a osw data file."
@@ -3056,182 +2837,66 @@
                     }
                 }
             },
-            "OSWConfidenceRequest": {
-                "type": "object",
-                "required": [
-                    "tdei_record_id"
-                ],
-                "properties": {
-                    "tdei_record_id": {
-                        "type": "string",
-                        "description": "TDEI record ID of the dataset to calculate confidence metric",
-                        "example": "5e991e7a-5c16-4ebf-ad31-3a3625bcca10"
-                    }
-                }
-            },
-            "OSWConfidenceResponse": {
-                "type": "object",
-                "properties": {
-                    "tdei_record_id": {
-                        "type": "string",
-                        "description": "TDEI record ID of the dataset to calculate confidence metric",
-                        "example": "5e991e7a-5c16-4ebf-ad31-3a3625bcca10"
-                    },
-                    "job_id": {
-                        "type": "integer",
-                        "description": "job_id of the confidence request",
-                        "example": 1
-                    }
-                }
-            },
-            "OSWConfidenceStatus": {
+            "JobDetails": {
                 "type": "object",
                 "properties": {
                     "job_id": {
                         "type": "integer",
-                        "description": "job_id of the confidence request",
-                        "example": 1
-                    },
-                    "confidenceValue": {
-                        "type": "number",
-                        "description": "Confidence of the record",
-                        "example": 90.23
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "description": "Date time of the last update on status",
-                        "example": "2018-02-10T09:30Z"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "status of the job",
-                        "enum": [
-                            "started",
-                            "calculated",
-                            "failed"
-                        ]
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Error message or status information"
-                    }
-                }
-            },
-            "ValidationStatus": {
-                "type": "object",
-                "properties": {
-                    "job_id": {
-                        "type": "integer",
-                        "description": "job_id of the Validation request",
-                        "example": 1
-                    },
-                    "validation_result": {
-                        "type": "string",
-                        "description": "Validation result"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "description": "Date time of the last update on status",
-                        "example": "2018-02-10T09:30Z"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "status of the job",
-                        "enum": [
-                            "in-progress",
-                            "completed"
-                        ]
-                    }
-                }
-            },
-            "OSWFormatResponse": {
-                "type": "object",
-                "properties": {
-                    "job_id": {
-                        "type": "string",
-                        "description": "job_id of the format request"
-                    }
-                }
-            },
-            "OSWFormatStatusResponse": {
-                "type": "object",
-                "required": [
-                    "job_id"
-                ],
-                "properties": {
-                    "job_id": {
-                        "type": "string",
-                        "description": "job_id of the format request"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Status of the format request",
-                        "enum": [
-                            "started",
-                            "completed",
-                            "failed"
-                        ]
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Any error message during failure"
-                    },
-                    "downloadUrl": {
-                        "type": "string",
-                        "description": "URL to download the converted file"
-                    },
-                    "conversion": {
-                        "type": "string",
-                        "description": "type of conversion",
-                        "example": "osw-osm"
-                    }
-                }
-            },
-            "FlatteningStatus": {
-                "type": "object",
-                "properties": {
-                    "job_id": {
-                        "type": "integer",
-                        "description": "job_id of the Flattening request",
-                        "example": 1
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "message of the Flattening request"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "status of the job",
-                        "enum": [
-                            "IN-PROGRESS",
-                            "COMPLETED"
-                        ]
-                    }
-                }
-            },
-            "DatasetBboxStatus": {
-                "type": "object",
-                "properties": {
-                    "job_id": {
-                        "type": "integer",
-                        "description": "job_id of the dataset bounding box request",
+                        "description": "job_id of the request",
                         "example": 1
                     },
                     "download_url": {
                         "type": "string",
-                        "description": "download_url of the dataset bounding box request"
+                        "description": "download_url for requested job. This will be available only if the job is completed and job_type required download_url"
                     },
                     "message": {
                         "type": "string",
-                        "description": "message of the dataset bounding box request"
+                        "description": "message of the job request"
                     },
                     "status": {
                         "type": "string",
-                        "description": "status of the job",
+                        "description": "status of the job request",
                         "enum": [
-                            "IN-PROGRESS",
-                            "COMPLETED"
+                            "COMPLETED",
+                            "FAILED",
+                            "IN-PROGRESS"
                         ]
+                    },
+                    "job_type": {
+                        "type": "string",
+                        "description": "job_type of the job request",
+                        "enum": [
+                            "Confidence-Calculate",
+                            "Dataset-Reformat",
+                            "Dataset-Upload",
+                            "Dataset-Publish",
+                            "Dataset-Validate",
+                            "Dataset-Flatten",
+                            "Dataset-Queries"
+                        ]
+                    },
+                    "tdei_project_group_id": {
+                        "type": "string",
+                        "description": "tdei project group id of the requested user",
+                        "example": "4e991e7a-5c16-4ebf-ad31-3a3625bcca10"
+                    },
+                    "tdei_project_group_name": {
+                        "type": "string",
+                        "description": "tdei project group name of the requested user",
+                        "example": "King County Metro"
+                    },
+                    "requested_by": {
+                        "type": "string",
+                        "description": "requested by username of the job request",
+                        "example": "John.Doe@transit.com"
+                    },
+                    "request_input": {
+                        "type": "object",
+                        "description": "request input of the job request"
+                    },
+                    "response_props": {
+                        "type": "object",
+                        "description": "response properties of the job request"
                     }
                 }
             }


### PR DESCRIPTION
1. Renamed `tdei_record_id` to `tdei_dataset_id`.
2. Removed job status endpoints for upload, publish, convert, confidence, bbox, and flattening requests.
3. Removed file download endpoint for convert, bbox requests.
4. Introduced two new API endpoints:
   - `/api/v1/job`
   - `/api/v1/job/download/:jobid`
5. Moved the invalidate API from the OSW controller to the general controller.
6. Changed `/confidence/calculate/:{tdei_dataset_id}` to `/confidence/calculate/:{tdei_dataset_id}` instead of getting `tdei_dataset_id` in the body request.