### PR TITLE
Added data_viewer_allowed key in project_group to strict boolean in datasets API

### DIFF
--- a/tdei-api-gateway-prod.json
+++ b/tdei-api-gateway-prod.json
@@ -4092,6 +4092,11 @@
                             "tdei_project_group_id": {
                                 "type": "string",
                                 "example": "4e991e7a-5c16-4ebf-ad31-3a3625bcca10"
+                            },
+                            "dataset_viewer_allowed": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Flag to indicate to allow dataset to be viewed on the dataset viewer."
                             }
                         },
                         "required": [

--- a/tdei-api-gateway-stage.json
+++ b/tdei-api-gateway-stage.json
@@ -4092,6 +4092,11 @@
                             "tdei_project_group_id": {
                                 "type": "string",
                                 "example": "4e991e7a-5c16-4ebf-ad31-3a3625bcca10"
+                            },
+                            "dataset_viewer_allowed": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Flag to indicate to allow dataset to be viewed on the dataset viewer."
                             }
                         },
                         "required": [

--- a/tdei-api-gateway.json
+++ b/tdei-api-gateway.json
@@ -4148,6 +4148,11 @@
                             "tdei_project_group_id": {
                                 "type": "string",
                                 "example": "4e991e7a-5c16-4ebf-ad31-3a3625bcca10"
+                            },
+                            "dataset_viewer_allowed": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Flag to indicate to allow dataset to be viewed on the dataset viewer."
                             }
                         },
                         "required": [


### PR DESCRIPTION
## DevBoard Task

## Changes Introduced
-  getDatasets to always return a strict boolean for osw.project_group.data_viewer_allowed, and adds comprehensive unit tests covering truthy/falsy inputs.

## Impacted Areas for Testing
-  TDEI Portal